### PR TITLE
Fix OCR start function

### DIFF
--- a/src/components/OcrOverlay.tsx
+++ b/src/components/OcrOverlay.tsx
@@ -126,7 +126,7 @@ const OcrOverlay: React.FC<OcrOverlayProps> = ({
             {lines.map(line => (
                 <div
                     key={line.id}
-                    ref={el => lineRefs.current.set(line.id, el)}
+                    ref={el => { lineRefs.current.set(line.id, el); }}
                     className="ocr-overlay-line"
                     style={{
                         top: `${line.y}px`,

--- a/src/hooks/useTypoCorrection.ts
+++ b/src/hooks/useTypoCorrection.ts
@@ -108,7 +108,7 @@ export const useTypoCorrection = ({
                 wordsAndSpacesOnLine.forEach((textSegment) => {
                     const partId = `${existingLine.id}-part-${partIdCounter++}`;
                     if (textSegment.match(/^\s+$/)) {
-                        newParts.push({ id: partId, text: textSegment, isWhitespace: true, ref: React.createRef<HTMLSpanElement>() });
+                        newParts.push({ id: partId, text: textSegment, isWhitespace: true, ref: React.createRef<HTMLSpanElement>() as React.RefObject<HTMLSpanElement> });
                     } else {
                         let isFlagged = false;
                         if (
@@ -131,7 +131,7 @@ export const useTypoCorrection = ({
                             text: textSegment,
                             isWhitespace: false,
                             isFlagged,
-                            ref: React.createRef<HTMLSpanElement>(),
+                            ref: React.createRef<HTMLSpanElement>() as React.RefObject<HTMLSpanElement>,
                         });
                     }
                 });
@@ -155,7 +155,7 @@ export const useTypoCorrection = ({
                             text: p,
                             isWhitespace: p.match(/^\s+$/) !== null,
                             isFlagged: false,
-                            ref: React.createRef<HTMLSpanElement>(),
+                            ref: React.createRef<HTMLSpanElement>() as React.RefObject<HTMLSpanElement>,
                         })),
                 }))
             );


### PR DESCRIPTION
## Summary
- wire in useOcrProcessing hook
- fix OCR overlay ref callback
- update typo correction types

## Testing
- `npm run lint`
- `npm run build` *(fails: TypeScript errors)*