### PR TITLE
Add OCR overlay during video playback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -289,6 +289,23 @@
   box-sizing: border-box;
 }
 
+.base-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1;
+}
+
+.writing-video {
+  position: relative;
+  z-index: 2;
+}
+
+.hidden-during-video {
+  opacity: 0;
+}
+
 .status-text-container {
   position: absolute;
   bottom: -35px;


### PR DESCRIPTION
## Summary
- start OCR after video begins
- fade out media once video ends and OCR done
- display screenshot underneath video and overlay detection results
- adjust styles for layered media elements

## Testing
- `npm run build` *(fails: TypeScript errors)*
- `npm run lint` *(fails: 5 errors, 4 warnings)*