### PR TITLE
Ensure OCR overlay visible over video

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -63,7 +63,14 @@
 }
 
 .overlay-container{
-  background-color: orange;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 3;
+  pointer-events: none;
+  background-color: transparent;
   color: black;
 }
 
@@ -287,6 +294,21 @@
   max-width: 100%;
   height: auto;
   box-sizing: border-box;
+}
+
+.screenshot-underlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: auto;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.media-container video {
+  position: relative;
+  z-index: 2;
 }
 
 .status-text-container {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,16 +44,13 @@ function App() {
     const [shouldStartOcr, setShouldStartOcr] = useState<boolean>(false);
     const [isShowingTypoHighlights, setIsShowingTypoHighlights] = useState<boolean>(false);
     const [currentAppPhase, setCurrentAppPhase] = useState<number>(0);
-    const [showMediaElement, setShowMediaElement] = useState<boolean>(true);
+    const [showMediaElement] = useState<boolean>(true);
+
+    const hasStartedAutoOcr = useRef<boolean>(false);
 
     const [interactiveOcrParts, setInteractiveOcrParts] = useState<DisplayTextPart[]>([]);
     const [backendCorrectedSentence, setBackendCorrectedSentence] = useState<string>('');
     const [isTypoCheckingAPILoading, setIsTypoCheckingAPILoading] = useState<boolean>(false);
-
-    const resetTypoData = () => {
-        setInteractiveOcrParts([]);
-        setBackendCorrectedSentence('');
-    };
 
 
     const imageRef = useRef<HTMLImageElement | null>(null);
@@ -89,9 +86,9 @@ function App() {
         }
     }, [modelLoadError]);
 
-    useEffect(() => { /* ... Image Dimension Loading ... */
+    useEffect(() => {
         const imgElement = imageRef.current;
-        if (imgElement && !isVideoPlaying) {
+        if (imgElement) {
             const handleLoad = () => {
                 if (imgElement.offsetWidth > 0 && imgElement.offsetHeight > 0) {
                     setImageDimensions({ width: imgElement.offsetWidth, height: imgElement.offsetHeight });
@@ -118,20 +115,16 @@ function App() {
                 imgElement.addEventListener('error', handleErrorLoad);
             }
             return () => {
-                if(imgElement){ 
+                if(imgElement){
                     imgElement.removeEventListener('load', handleLoad);
                     imgElement.removeEventListener('error', handleErrorLoad);
                 }
             };
         }
-
-
-    }, [isVideoPlaying]);
+    }, []);
     const handleVideoEnd = () => {
-        log('Video ended. Switching to image and queueing OCR.');
+        log('Video ended.');
         setIsVideoPlaying(false);
-        setCurrentAppPhase(1);
-        setShouldStartOcr(true);
     };
 
     const handleTypoCorrectionAPI = useCallback(async (textToCorrect: string) => { /* MODIFIED to build parts correctly */
@@ -225,53 +218,35 @@ function App() {
         finally { setIsTypoCheckingAPILoading(false); setCurrentAppPhase(2); }
     }, [ocrDisplayLines, setOcrDisplayLines]);
 
-    const handleImageClick = useCallback(async () => {
-        if (isVideoPlaying || !imageDimensions) return;
-        if (isProcessingOCR || !tfReady || isLoadingModel || !imageRef.current?.complete) {
-            warn('Not ready for OCR processing.', { isProcessingOCR, tfReady, isLoadingModel, imgComplete: !!imageRef.current?.complete });
-            return;
-        }
 
-        setCurrentAppPhase(1);
-        setShowMediaElement(true);
-        resetTypoData();
-        setShowMediaElement(true);
-        setInteractiveOcrParts([]);
-        setBackendCorrectedSentence('');
-        setIsShowingTypoHighlights(false);
-        ocrDisplayLinesRefs.current.clear();
-
-
-        const rawText = await startOcr(imageDimensions!);
-
-        if (mediaContainerRef.current) {
-            gsap.to(mediaContainerRef.current, {
-                opacity: 0,
-                duration: 0.5,
-                onComplete: () => {
-                    setShowMediaElement(false);
-                    setCurrentAppPhase(2);
-                    if (rawText.trim().length > 0) {
-                        handleTypoCorrectionAPI(rawText).catch(() => {});
-                    }
-                }
-            });
-        } else {
-            setShowMediaElement(false);
-            setCurrentAppPhase(2);
-            if (rawText.trim().length > 0) {
-                await handleTypoCorrectionAPI(rawText);
-            }
-        }
-    }, [imageDimensions, isVideoPlaying, isProcessingOCR, tfReady, isLoadingModel, startOcr, handleTypoCorrectionAPI]);
-
-    useEffect(() => { // Auto-trigger OCR
-        if (shouldStartOcr && !isVideoPlaying && imageDimensions && imageRef.current?.complete && imageRef.current.naturalWidth > 0) {
+    useEffect(() => {
+        if (shouldStartOcr && imageDimensions && imageRef.current?.complete && !isProcessingOCR) {
             log('Auto-starting OCR process.');
-            handleImageClick();
-            setShouldStartOcr(false);
+            setCurrentAppPhase(1);
+            startOcr(imageDimensions)
+                .then(raw => {
+                    if (raw.trim().length > 0) {
+                        handleTypoCorrectionAPI(raw).catch(() => {});
+                    } else {
+                        setCurrentAppPhase(2);
+                    }
+                })
+                .catch(() => {})
+                .finally(() => {
+                    setShouldStartOcr(false);
+                });
         }
-    }, [shouldStartOcr, isVideoPlaying, imageDimensions, handleImageClick]);
+    }, [shouldStartOcr, imageDimensions, isProcessingOCR, startOcr, handleTypoCorrectionAPI]);
+
+    useEffect(() => {
+        if (isVideoPlaying && !hasStartedAutoOcr.current) {
+            const timer = setTimeout(() => {
+                hasStartedAutoOcr.current = true;
+                setShouldStartOcr(true);
+            }, 400);
+            return () => clearTimeout(timer);
+        }
+    }, [isVideoPlaying]);
     
 
     useEffect(() => { // GSAP Animation for Typo Highlighting (on existing text parts)
@@ -401,17 +376,31 @@ function App() {
         <div className="app-container">
             <h1>Theo Kremer</h1> {/* MODIFIED Header */}
 
-            <div className="media-wrapper"> {/* New wrapper for media and status text */}
+            <div className="media-wrapper">
                 <div ref={mediaContainerRef} className={`media-container ${!showMediaElement ? 'hidden-media' : ''}`}>
-                    {isVideoPlaying ? (
-                        <video ref={videoRef} src="/text_writing.mp4" autoPlay muted onEnded={handleVideoEnd} playsInline > Your browser does not support the video tag. </video>
-                    ) : (
-                        // Image is primarily for structure; opacity is controlled by showMediaElement via CSS
-                        <img ref={imageRef} src="/text_screenshot.png" alt="Text input for OCR" style={{cursor: 'default' }} crossOrigin="anonymous" />
+                    <img
+                        ref={imageRef}
+                        src="/text_screenshot.png"
+                        alt="Text input for OCR"
+                        className="screenshot-underlay"
+                        style={{ cursor: 'default', opacity: isVideoPlaying ? 0 : 1 }}
+                        crossOrigin="anonymous"
+                    />
+                    {isVideoPlaying && (
+                        <video
+                            ref={videoRef}
+                            src="/text_writing.mp4"
+                            autoPlay
+                            muted
+                            onEnded={handleVideoEnd}
+                            playsInline
+                        >
+                            Your browser does not support the video tag.
+                        </video>
                     )}
                 </div>
                 {/* OCR Overlay Text & Highlights - This is now always "active" after video, its content changes */}
-                {!isVideoPlaying && imageDimensions && (
+                {imageDimensions && (
                     <OcrOverlay
                         lines={ocrDisplayLines}
                         isShowingHighlights={isShowingTypoHighlights}

--- a/src/components/OcrOverlay.tsx
+++ b/src/components/OcrOverlay.tsx
@@ -92,7 +92,8 @@ const OcrOverlay: React.FC<OcrOverlayProps> = ({
         width: imageDimensions.width - 8 + 'px',
         height: imageDimensions.height - 8 + 'px',
         pointerEvents: 'none',
-        overflow: 'hidden'
+        overflow: 'hidden',
+        zIndex: 3
     };
 
     const renderActiveBox = () => {


### PR DESCRIPTION
## Summary
- raise overlay z-index so bounding boxes show on the playing video
- clean up unused handlers and trigger typo correction after OCR completes

## Testing
- `npx tsc -b`